### PR TITLE
Techdebt: Move imports around

### DIFF
--- a/mazure/azure_services/__init__.py
+++ b/mazure/azure_services/__init__.py
@@ -1,3 +1,16 @@
+from peewee import SqliteDatabase
+
+from ..azure_services.management.graph.models.application import Application
+from ..azure_services.management.storage.models.async_operation import (
+    AsyncStorageOperation,
+)
+from ..azure_services.management.storage.models.storage_account import (
+    StorageAccount,
+    StorageAccountKey,
+    StorageAccountKeyLink,
+)
+from ..azure_services.storage.models.blob import Blob
+from ..azure_services.storage.models.storage_container import StorageContainer
 from .login import responses as login_responses
 from .management.graph import responses as graph_responses
 from .management.operation_results import responses as operation_result_responses
@@ -5,3 +18,18 @@ from .management.resource_groups import responses as resource_group_responses
 from .management.storage import responses as storage_management_responses
 from .management.subscriptions import responses as subscription_response
 from .storage import responses as storage_responses
+
+tables = [
+    Application,
+    AsyncStorageOperation,
+    Blob,
+    StorageAccount,
+    StorageAccountKey,
+    StorageAccountKeyLink,
+    StorageContainer,
+]
+
+db = SqliteDatabase("/tmp/mazure.db")
+
+db.bind(tables)
+db.create_tables(tables)

--- a/mazure/azure_services/login/responses.py
+++ b/mazure/azure_services/login/responses.py
@@ -8,7 +8,8 @@ from urllib.parse import unquote
 
 import jwt
 
-from mazure.mazure_core import MazureRequest, ResponseType
+from mazure.mazure_core import ResponseType
+from mazure.mazure_core.mazure_request import MazureRequest
 from mazure.mazure_core.route_mapping import register
 
 

--- a/mazure/azure_services/management/graph/responses.py
+++ b/mazure/azure_services/management/graph/responses.py
@@ -4,7 +4,8 @@ import re
 import string
 from uuid import uuid4
 
-from mazure.mazure_core import MazureRequest, ResponseType
+from mazure.mazure_core import ResponseType
+from mazure.mazure_core.mazure_request import MazureRequest
 from mazure.mazure_core.route_mapping import register
 from mazure.mazure_proxy.utils import chunk_body
 

--- a/mazure/azure_services/management/operation_results/responses.py
+++ b/mazure/azure_services/management/operation_results/responses.py
@@ -1,6 +1,7 @@
 import re
 
-from mazure.mazure_core import MazureRequest, ResponseType
+from mazure.mazure_core import ResponseType
+from mazure.mazure_core.mazure_request import MazureRequest
 from mazure.mazure_core.route_mapping import register
 
 

--- a/mazure/azure_services/management/resource_groups/responses.py
+++ b/mazure/azure_services/management/resource_groups/responses.py
@@ -3,7 +3,8 @@ import random
 import re
 import string
 
-from mazure.mazure_core import MazureRequest, ResponseType
+from mazure.mazure_core import ResponseType
+from mazure.mazure_core.mazure_request import MazureRequest
 from mazure.mazure_core.route_mapping import register
 
 from . import model

--- a/mazure/azure_services/management/storage/responses.py
+++ b/mazure/azure_services/management/storage/responses.py
@@ -3,7 +3,8 @@ import random
 import re
 import string
 
-from mazure.mazure_core import MazureRequest, ResponseType
+from mazure.mazure_core import ResponseType
+from mazure.mazure_core.mazure_request import MazureRequest
 from mazure.mazure_core.route_mapping import register
 
 from .models.async_operation import AsyncStorageOperation

--- a/mazure/azure_services/management/subscriptions/responses.py
+++ b/mazure/azure_services/management/subscriptions/responses.py
@@ -1,7 +1,8 @@
 import json
 import re
 
-from mazure.mazure_core import MazureRequest, ResponseType
+from mazure.mazure_core import ResponseType
+from mazure.mazure_core.mazure_request import MazureRequest
 from mazure.mazure_core.route_mapping import register
 
 from . import sub_model

--- a/mazure/azure_services/storage/responses.py
+++ b/mazure/azure_services/storage/responses.py
@@ -1,7 +1,8 @@
 import re
 from datetime import datetime
 
-from mazure.mazure_core import MazureRequest, ResponseType
+from mazure.mazure_core import ResponseType
+from mazure.mazure_core.mazure_request import MazureRequest
 from mazure.mazure_core.route_mapping import register
 
 from .models.blob import Blob

--- a/mazure/mazure_core/__init__.py
+++ b/mazure/mazure_core/__init__.py
@@ -1,33 +1,3 @@
 from typing import Any, Dict, Tuple
 
-from peewee import SqliteDatabase
-
-from ..azure_services.management.graph.models.application import Application
-from ..azure_services.management.storage.models.async_operation import (
-    AsyncStorageOperation,
-)
-from ..azure_services.management.storage.models.storage_account import (
-    StorageAccount,
-    StorageAccountKey,
-    StorageAccountKeyLink,
-)
-from ..azure_services.storage.models.blob import Blob
-from ..azure_services.storage.models.storage_container import StorageContainer
-from .mazure_request import MazureRequest
-
 ResponseType = Tuple[int, Dict[str, Any], bytes]
-
-tables = [
-    Application,
-    AsyncStorageOperation,
-    Blob,
-    StorageAccount,
-    StorageAccountKey,
-    StorageAccountKeyLink,
-    StorageContainer,
-]
-
-db = SqliteDatabase("/tmp/mazure.db")
-
-db.bind(tables)
-db.create_tables(tables)

--- a/mazure/mazure_core/route_mapping.py
+++ b/mazure/mazure_core/route_mapping.py
@@ -1,6 +1,7 @@
 from typing import Callable, Dict, Pattern
 
-from mazure.mazure_core import MazureRequest, ResponseType
+from mazure.mazure_core import ResponseType
+from mazure.mazure_core.mazure_request import MazureRequest
 
 registered_services: Dict[
     str, Dict[str, Dict[Pattern[str], Callable[[MazureRequest], ResponseType]]]

--- a/mazure/mazure_core/service_discovery.py
+++ b/mazure/mazure_core/service_discovery.py
@@ -2,7 +2,8 @@ import re
 from gzip import compress
 from typing import Any, Dict
 
-from mazure.mazure_core import MazureRequest, ResponseType
+from mazure.mazure_core import ResponseType
+from mazure.mazure_core.mazure_request import MazureRequest
 
 from .route_mapping import registered_services  # pylint: disable
 

--- a/mazure/mazure_proxy/proxy3.py
+++ b/mazure/mazure_proxy/proxy3.py
@@ -7,7 +7,7 @@ from typing import Any, Dict
 from urllib.parse import urlparse
 
 from mazure import azure_services  # pylint: disable=unused-import
-from mazure.mazure_core import MazureRequest
+from mazure.mazure_core.mazure_request import MazureRequest
 from mazure.mazure_core.service_discovery import execute
 
 from . import debug, info

--- a/tests/tests_python/test_models/test_graph_applications.py
+++ b/tests/tests_python/test_models/test_graph_applications.py
@@ -1,5 +1,3 @@
-from unittest import TestCase
-
 from peewee import SqliteDatabase
 
 from mazure.azure_services.management.graph.models import graph_backend
@@ -11,23 +9,23 @@ from mazure.azure_services.management.graph.models.application import (
 MODELS = [Application, DeletedApplication]
 
 # use an in-memory SQLite for tests.
-test_db = SqliteDatabase(":memory:")
+_test_db = SqliteDatabase(":memory:")
 
 
-class TestGraphApplications(TestCase):
-    def setUp(self) -> None:
+class TestGraphApplications:
+    def setup_method(self) -> None:
         # Bind model classes to test db. Since we have a complete list of
         # all models, we do not need to recursively bind dependencies.
-        test_db.bind(MODELS, bind_refs=False, bind_backrefs=False)
+        _test_db.bind(MODELS, bind_refs=False, bind_backrefs=False)
 
-        test_db.connect()
-        test_db.create_tables(MODELS)
+        _test_db.connect()
+        _test_db.create_tables(MODELS)
 
-    def tearDown(self) -> None:
-        test_db.drop_tables(MODELS)
+    def teardown_method(self) -> None:
+        _test_db.drop_tables(MODELS)
 
         # Close connection to db.
-        test_db.close()
+        _test_db.close()
 
     def test_applications_lifecycle(self) -> None:
         assert not graph_backend.list_applications()

--- a/tests/tests_python/test_requests/storage/test_blob_storage.py
+++ b/tests/tests_python/test_requests/storage/test_blob_storage.py
@@ -32,25 +32,25 @@ MODELS = [
 ]
 
 # use an in-memory SQLite for tests.
-test_db = SqliteDatabase(":memory:")
+_test_db = SqliteDatabase(":memory:")
 
 
 class TestStorageAccounts:
-    def setup(self) -> None:
+    def setup_method(self) -> None:
         # Bind model classes to test db. Since we have a complete list of
         # all models, we do not need to recursively bind dependencies.
-        test_db.bind(MODELS, bind_refs=False, bind_backrefs=False)
+        _test_db.bind(MODELS, bind_refs=False, bind_backrefs=False)
 
-        test_db.connect()
-        test_db.create_tables(MODELS)
+        _test_db.connect()
+        _test_db.create_tables(MODELS)
 
         # create group
 
-    def teardown(self) -> None:
-        test_db.drop_tables(MODELS)
+    def teardown_method(self) -> None:
+        _test_db.drop_tables(MODELS)
 
         # Close connection to db.
-        test_db.close()
+        _test_db.close()
 
     def test_create_container(self) -> None:
         # Create StorageAccount

--- a/tests/tests_python/test_requests/storage/test_storage_account.py
+++ b/tests/tests_python/test_requests/storage/test_storage_account.py
@@ -27,25 +27,25 @@ MODELS = [
 ]
 
 # use an in-memory SQLite for tests.
-test_db = SqliteDatabase(":memory:")
+_test_db = SqliteDatabase(":memory:")
 
 
 class TestStorageAccounts:
-    def setup(self) -> None:
+    def setup_method(self) -> None:
         # Bind model classes to test db. Since we have a complete list of
         # all models, we do not need to recursively bind dependencies.
-        test_db.bind(MODELS, bind_refs=False, bind_backrefs=False)
+        _test_db.bind(MODELS, bind_refs=False, bind_backrefs=False)
 
-        test_db.connect()
-        test_db.create_tables(MODELS)
+        _test_db.connect()
+        _test_db.create_tables(MODELS)
 
         # create group
 
-    def teardown(self) -> None:
-        test_db.drop_tables(MODELS)
+    def teardown_method(self) -> None:
+        _test_db.drop_tables(MODELS)
 
         # Close connection to db.
-        test_db.close()
+        _test_db.close()
 
     def test_name_exists(self) -> None:
         storage_container_name = "storage_container"

--- a/tests/tests_python/test_requests/test_application_requests.py
+++ b/tests/tests_python/test_requests/test_application_requests.py
@@ -22,23 +22,23 @@ from .. import load_responses  # pylint: disable=W0611
 MODELS = [Application, DeletedApplication]
 
 # use an in-memory SQLite for tests.
-test_db = SqliteDatabase(":memory:")
+_test_db = SqliteDatabase(":memory:")
 
 
 class TestGraphApplications:
-    def setup(self) -> None:
+    def setup_method(self) -> None:
         # Bind model classes to test db. Since we have a complete list of
         # all models, we do not need to recursively bind dependencies.
-        test_db.bind(MODELS, bind_refs=False, bind_backrefs=False)
+        _test_db.bind(MODELS, bind_refs=False, bind_backrefs=False)
 
-        test_db.connect()
-        test_db.create_tables(MODELS)
+        _test_db.connect()
+        _test_db.create_tables(MODELS)
 
-    def teardown(self) -> None:
-        test_db.drop_tables(MODELS)
+    def teardown_method(self) -> None:
+        _test_db.drop_tables(MODELS)
 
         # Close connection to db.
-        test_db.close()
+        _test_db.close()
 
     def test_list_application(self) -> None:
         resp = requests.get("https://graph.microsoft.com/v1.0/applications", timeout=2)


### PR DESCRIPTION
Moving the database to `azure_services` is a better delineation of responsibilities

This PR also changes some test names/methods to resolve Pytest warnings