### PR TITLE
Techdebt: Reuse paths and remove duplication in routing - Pt1

### DIFF
--- a/mazure/azure_services/login/responses.py
+++ b/mazure/azure_services/login/responses.py
@@ -1,7 +1,6 @@
 import base64
 import json
 import random
-import re
 import string
 from datetime import datetime, timezone
 from urllib.parse import unquote
@@ -10,12 +9,22 @@ import jwt
 
 from mazure.mazure_core import ResponseType
 from mazure.mazure_core.mazure_request import MazureRequest
-from mazure.mazure_core.route_mapping import register
+from mazure.mazure_core.route_mapping import register, register_parent
+
+
+@register_parent(path="https://login.microsoftonline.com")
+class MicrosoftLogin:
+    pass
+
+
+@register_parent(path="http://169.254.169.254")
+class ManagedIdentityServer:
+    pass
 
 
 @register(
-    "https://login.microsoftonline.com",
-    path=re.compile("^/[-a-z0-9A-Z]+/.well-known/openid-configuration$"),
+    parent=MicrosoftLogin,
+    path=r"/[-a-z0-9A-Z]+/.well-known/openid-configuration$",
     method="GET",
 )
 def get_wellknown_endpoint(request: MazureRequest) -> ResponseType:
@@ -23,8 +32,8 @@ def get_wellknown_endpoint(request: MazureRequest) -> ResponseType:
 
 
 @register(
-    "https://login.microsoftonline.com",
-    path=re.compile("^/[-a-z0-9A-Z]+/v2.0/.well-known/openid-configuration$"),
+    parent=MicrosoftLogin,
+    path=r"/[-a-z0-9A-Z]+/v2.0/.well-known/openid-configuration$",
     method="GET",
 )
 def get_wellknown_endpoint_2(
@@ -91,8 +100,8 @@ def get_wellknown_endpoint_2(
 
 
 @register(
-    "https://login.microsoftonline.com",
-    path=re.compile("^/[-a-z0-9A-Z]+/oauth2/v2.0/token$"),
+    parent=MicrosoftLogin,
+    path=r"/[-a-z0-9A-Z]+/oauth2/v2.0/token$",
     method="POST",
 )
 def get_oauth_token(
@@ -151,8 +160,8 @@ def get_oauth_token(
 
 
 @register(
-    "http://169.254.169.254",
-    path=re.compile("^/metadata/identity/oauth2/token$"),
+    parent=ManagedIdentityServer,
+    path=r"/metadata/identity/oauth2/token$",
     method="GET",
 )
 def get_oauth_token__managed_identity(

--- a/mazure/azure_services/management/__init__.py
+++ b/mazure/azure_services/management/__init__.py
@@ -1,0 +1,11 @@
+from mazure.mazure_core.route_mapping import register_parent
+
+
+@register_parent(path="https://graph.microsoft.com")
+class GraphHost:
+    pass
+
+
+@register_parent(path="https://management.azure.com")
+class ManagementWebsite:
+    pass

--- a/mazure/azure_services/management/graph/responses.py
+++ b/mazure/azure_services/management/graph/responses.py
@@ -9,12 +9,13 @@ from mazure.mazure_core.mazure_request import MazureRequest
 from mazure.mazure_core.route_mapping import register
 from mazure.mazure_proxy.utils import chunk_body
 
+from .. import GraphHost
 from .models import graph_backend
 
 
 @register(
-    "https://graph.microsoft.com",
-    path=re.compile(r"^/v1.0/applications$"),
+    parent=GraphHost,
+    path=r"/v1.0/applications$",
     method="GET",
 )
 def list_applications(
@@ -34,8 +35,8 @@ def list_applications(
 
 
 @register(
-    "https://graph.microsoft.com",
-    path=re.compile(r"^/v1.0/applications$"),
+    parent=GraphHost,
+    path=r"/v1.0/applications$",
     method="POST",
 )
 def create_application(
@@ -53,8 +54,8 @@ def create_application(
 
 
 @register(
-    "https://graph.microsoft.com",
-    path=re.compile(r"^/v1.0/applications/[^/]+$"),
+    parent=GraphHost,
+    path=r"/v1.0/applications/[^/]+$",
     method="GET",
 )
 def get_application(request: MazureRequest) -> ResponseType:
@@ -73,8 +74,8 @@ def get_application(request: MazureRequest) -> ResponseType:
 
 
 @register(
-    "https://graph.microsoft.com",
-    path=re.compile(r"^/v1.0/applications\(appId='[-a-z0-9A-Z]+'\)$"),
+    parent=GraphHost,
+    path=r"/v1.0/applications\(appId='[-a-z0-9A-Z]+'\)$",
     method="GET",
 )
 def get_application_by_app_id(request: MazureRequest) -> ResponseType:
@@ -93,8 +94,8 @@ def get_application_by_app_id(request: MazureRequest) -> ResponseType:
 
 
 @register(
-    "https://graph.microsoft.com",
-    path=re.compile(r"^/v1.0/applications/[-a-z0-9A-Z]+$"),
+    parent=GraphHost,
+    path=r"/v1.0/applications/[-a-z0-9A-Z]+$",
     method="PATCH",
 )
 def update_application(request: MazureRequest) -> ResponseType:
@@ -109,8 +110,8 @@ def update_application(request: MazureRequest) -> ResponseType:
 
 
 @register(
-    "https://graph.microsoft.com",
-    path=re.compile(r"^/v1.0/applications\(appId='[-a-z0-9A-Z]+'\)$"),
+    parent=GraphHost,
+    path=r"/v1.0/applications\(appId='[-a-z0-9A-Z]+'\)$",
     method="PATCH",
 )
 def update_application_by_app_id(request: MazureRequest) -> ResponseType:
@@ -125,8 +126,8 @@ def update_application_by_app_id(request: MazureRequest) -> ResponseType:
 
 
 @register(
-    "https://graph.microsoft.com",
-    path=re.compile(r"^/v1.0/applications/[-a-z0-9A-Z]+$"),
+    parent=GraphHost,
+    path=r"/v1.0/applications/[-a-z0-9A-Z]+$",
     method="DELETE",
 )
 def delete_application(request: MazureRequest) -> ResponseType:
@@ -138,8 +139,8 @@ def delete_application(request: MazureRequest) -> ResponseType:
 
 
 @register(
-    "https://graph.microsoft.com",
-    path=re.compile(r"^/v1.0/applications\(appId='[-a-z0-9A-Z]+'\)$"),
+    parent=GraphHost,
+    path=r"/v1.0/applications\(appId='[-a-z0-9A-Z]+'\)$",
     method="DELETE",
 )
 def delete_application_by_app_id(request: MazureRequest) -> ResponseType:
@@ -151,8 +152,8 @@ def delete_application_by_app_id(request: MazureRequest) -> ResponseType:
 
 
 @register(
-    "https://graph.microsoft.com",
-    path=re.compile(r"^/directory/deleteditems/microsoft.graph.application$"),
+    parent=GraphHost,
+    path=r"/directory/deleteditems/microsoft.graph.application$",
     method="GET",
 )
 def list_deleted_applications(
@@ -172,8 +173,8 @@ def list_deleted_applications(
 
 
 @register(
-    "https://graph.microsoft.com",
-    path=re.compile(r"^/v1.0/applications/[-a-z0-9A-Z]+/addPassword$"),
+    parent=GraphHost,
+    path=r"/v1.0/applications/[-a-z0-9A-Z]+/addPassword$",
     method="POST",
 )
 def add_password(
@@ -206,8 +207,8 @@ def add_password(
 
 
 @register(
-    "https://graph.microsoft.com",
-    path=re.compile(r"^/v1.0/servicePrincipals$"),
+    parent=GraphHost,
+    path=r"/v1.0/servicePrincipals$",
     method="POST",
 )
 def create_service_principal(

--- a/mazure/azure_services/management/operation_results/responses.py
+++ b/mazure/azure_services/management/operation_results/responses.py
@@ -1,13 +1,13 @@
-import re
-
 from mazure.mazure_core import ResponseType
 from mazure.mazure_core.mazure_request import MazureRequest
 from mazure.mazure_core.route_mapping import register
 
+from .. import ManagementWebsite
+
 
 @register(
-    "https://management.azure.com",
-    path=re.compile("^/subscriptions/[-a-z0-9A-Z]+/operationresults/[-_a-z0-9A-Z]+$"),
+    parent=ManagementWebsite,
+    path=r"/subscriptions/[-a-z0-9A-Z]+/operationresults/[-_a-z0-9A-Z]+$",
     method="GET",
 )
 def get_operation_result(

--- a/mazure/azure_services/management/resource_groups/responses.py
+++ b/mazure/azure_services/management/resource_groups/responses.py
@@ -1,18 +1,18 @@
 import json
 import random
-import re
 import string
 
 from mazure.mazure_core import ResponseType
 from mazure.mazure_core.mazure_request import MazureRequest
 from mazure.mazure_core.route_mapping import register
 
+from .. import ManagementWebsite
 from . import model
 
 
 @register(
-    "https://management.azure.com",
-    path=re.compile("^/subscriptions/[-a-z0-9A-Z]+/resourcegroups/[-_a-z0-9A-Z]+$"),
+    parent=ManagementWebsite,
+    path=r"/subscriptions/[-a-z0-9A-Z]+/resourcegroups/[-_a-z0-9A-Z]+$",
     method="PUT",
 )
 def create_resource_group(request: MazureRequest) -> ResponseType:
@@ -34,8 +34,8 @@ def create_resource_group(request: MazureRequest) -> ResponseType:
 
 
 @register(
-    "https://management.azure.com",
-    path=re.compile("^/subscriptions/[-a-z0-9A-Z]+/resourcegroups/[-_a-z0-9A-Z]+$"),
+    parent=ManagementWebsite,
+    path=r"/subscriptions/[-a-z0-9A-Z]+/resourcegroups/[-_a-z0-9A-Z]+$",
     method="HEAD",
 )
 def has_resource_group(request: MazureRequest) -> ResponseType:
@@ -46,8 +46,8 @@ def has_resource_group(request: MazureRequest) -> ResponseType:
 
 
 @register(
-    "https://management.azure.com",
-    path=re.compile("^/subscriptions/[-a-z0-9A-Z]+/resourcegroups/[-_a-z0-9A-Z]+$"),
+    parent=ManagementWebsite,
+    path=r"/subscriptions/[-a-z0-9A-Z]+/resourcegroups/[-_a-z0-9A-Z]+$",
     method="GET",
 )
 def get_resource_group(request: MazureRequest) -> ResponseType:
@@ -67,8 +67,8 @@ def get_resource_group(request: MazureRequest) -> ResponseType:
 
 
 @register(
-    "https://management.azure.com",
-    path=re.compile("^/subscriptions/[-a-z0-9A-Z]+/resourcegroups/[-_a-z0-9A-Z]+$"),
+    parent=ManagementWebsite,
+    path=r"/subscriptions/[-a-z0-9A-Z]+/resourcegroups/[-_a-z0-9A-Z]+$",
     method="DELETE",
 )
 def delete_resource_group(request: MazureRequest) -> ResponseType:
@@ -86,8 +86,8 @@ def delete_resource_group(request: MazureRequest) -> ResponseType:
 
 
 @register(
-    "https://management.azure.com",
-    path=re.compile("^/subscriptions/[-a-z0-9A-Z]+/resourcegroups$"),
+    parent=ManagementWebsite,
+    path=r"/subscriptions/[-a-z0-9A-Z]+/resourcegroups$",
     method="GET",
 )
 def list_resource_groups(request: MazureRequest) -> ResponseType:

--- a/mazure/azure_services/management/storage/responses.py
+++ b/mazure/azure_services/management/storage/responses.py
@@ -1,12 +1,12 @@
 import json
 import random
-import re
 import string
 
 from mazure.mazure_core import ResponseType
 from mazure.mazure_core.mazure_request import MazureRequest
 from mazure.mazure_core.route_mapping import register
 
+from .. import ManagementWebsite
 from .models.async_operation import AsyncStorageOperation
 from .models.storage_account import (
     StorageAccount,
@@ -16,10 +16,8 @@ from .models.storage_account import (
 
 
 @register(
-    host="https://management.azure.com",
-    path=re.compile(
-        "/subscriptions/[-a-z0-9A-Z]+/providers/Microsoft.Storage/checkNameAvailability"
-    ),
+    parent=ManagementWebsite,
+    path=r"/subscriptions/[-a-z0-9A-Z]+/providers/Microsoft.Storage/checkNameAvailability",
     method="POST",
 )
 def check_name_availability(request: MazureRequest) -> ResponseType:
@@ -38,10 +36,8 @@ def check_name_availability(request: MazureRequest) -> ResponseType:
 
 
 @register(
-    host="https://management.azure.com",
-    path=re.compile(
-        "/subscriptions/[-a-z0-9A-Z]+/resourceGroups/[-a-z0-9A-Z]+/providers/Microsoft.Storage/storageAccounts/[-_a-z0-9A-Z]+"
-    ),
+    parent=ManagementWebsite,
+    path=r"/subscriptions/[-a-z0-9A-Z]+/resourceGroups/[-a-z0-9A-Z]+/providers/Microsoft.Storage/storageAccounts/[-_a-z0-9A-Z]+",
     method="PUT",
 )
 def create_storage_account(request: MazureRequest) -> ResponseType:
@@ -84,10 +80,8 @@ def create_storage_account(request: MazureRequest) -> ResponseType:
 
 
 @register(
-    host="https://management.azure.com",
-    path=re.compile(
-        "/subscriptions/[-a-z0-9A-Z]+/providers/Microsoft.Storage/locations/[-a-z0-9A-Z]+/asyncoperations/[-a-z0-9A-Z]+"
-    ),
+    parent=ManagementWebsite,
+    path=r"/subscriptions/[-a-z0-9A-Z]+/providers/Microsoft.Storage/locations/[-a-z0-9A-Z]+/asyncoperations/[-a-z0-9A-Z]+",
     method="GET",
 )
 def get_result_async_operation(request: MazureRequest) -> ResponseType:
@@ -110,10 +104,8 @@ def get_result_async_operation(request: MazureRequest) -> ResponseType:
 
 
 @register(
-    host="https://management.azure.com",
-    path=re.compile(
-        "/subscriptions/[-a-z0-9A-Z]+/providers/Microsoft.Storage/storageAccounts"
-    ),
+    parent=ManagementWebsite,
+    path=r"/subscriptions/[-a-z0-9A-Z]+/providers/Microsoft.Storage/storageAccounts",
     method="GET",
 )
 def get_storage_accounts(
@@ -129,10 +121,8 @@ def get_storage_accounts(
 
 
 @register(
-    host="https://management.azure.com",
-    path=re.compile(
-        "/subscriptions/[-a-z0-9A-Z]+/resourceGroups/[-a-z0-9A-Z]+/providers/Microsoft.Storage/storageAccounts/[-_a-z0-9A-Z]+/listKeys"
-    ),
+    parent=ManagementWebsite,
+    path=r"/subscriptions/[-a-z0-9A-Z]+/resourceGroups/[-a-z0-9A-Z]+/providers/Microsoft.Storage/storageAccounts/[-_a-z0-9A-Z]+/listKeys",
     method="POST",
 )
 def list_keys(request: MazureRequest) -> ResponseType:

--- a/mazure/azure_services/management/subscriptions/responses.py
+++ b/mazure/azure_services/management/subscriptions/responses.py
@@ -1,16 +1,14 @@
 import json
-import re
 
 from mazure.mazure_core import ResponseType
 from mazure.mazure_core.mazure_request import MazureRequest
 from mazure.mazure_core.route_mapping import register
 
+from .. import ManagementWebsite
 from . import sub_model
 
 
-@register(
-    "https://management.azure.com", path=re.compile("^/subscriptions$"), method="GET"
-)
+@register(parent=ManagementWebsite, path=r"/subscriptions$", method="GET")
 def get_subscriptions(
     request: MazureRequest,  # pylint: disable=unused-argument
 ) -> ResponseType:
@@ -20,8 +18,8 @@ def get_subscriptions(
 
 
 @register(
-    "https://management.azure.com",
-    path=re.compile("^/subscriptions/[-a-z0-9A-Z]+/locations$"),
+    parent=ManagementWebsite,
+    path=r"/subscriptions/[-a-z0-9A-Z]+/locations$",
     method="GET",
 )
 def get_locations(request: MazureRequest) -> ResponseType:

--- a/mazure/azure_services/storage/responses.py
+++ b/mazure/azure_services/storage/responses.py
@@ -1,17 +1,21 @@
-import re
 from datetime import datetime
 
 from mazure.mazure_core import ResponseType
 from mazure.mazure_core.mazure_request import MazureRequest
-from mazure.mazure_core.route_mapping import register
+from mazure.mazure_core.route_mapping import register, register_parent
 
 from .models.blob import Blob
 from .models.storage_container import StorageContainer
 
 
+@register_parent(path="https://[-_a-z0-9A-Z]+.blob.core.windows.net")
+class StorageHost:
+    pass
+
+
 @register(
-    host="https://[-_a-z0-9A-Z]+.blob.core.windows.net",
-    path=re.compile("^/$"),
+    parent=StorageHost,
+    path=r"/$",
     method="GET",
 )
 def list_containers(request: MazureRequest) -> ResponseType:
@@ -23,8 +27,8 @@ def list_containers(request: MazureRequest) -> ResponseType:
 
 
 @register(
-    host="https://[-_a-z0-9A-Z]+.blob.core.windows.net",
-    path=re.compile("^/[-_a-z0-9A-Z]+$"),
+    parent=StorageHost,
+    path=r"/[-_a-z0-9A-Z]+$",
     method="PUT",
 )
 def create_container(request: MazureRequest) -> ResponseType:
@@ -47,8 +51,8 @@ def create_container(request: MazureRequest) -> ResponseType:
 
 
 @register(
-    host="https://[-_a-z0-9A-Z]+.blob.core.windows.net",
-    path=re.compile("^/[-_a-z0-9A-Z]+$"),
+    parent=StorageHost,
+    path=r"/[-_a-z0-9A-Z]+$",
     method="DELETE",
 )
 def delete_container(request: MazureRequest) -> ResponseType:
@@ -60,8 +64,8 @@ def delete_container(request: MazureRequest) -> ResponseType:
 
 
 @register(
-    host="https://[-_a-z0-9A-Z]+.blob.core.windows.net",
-    path=re.compile("^/[-_a-z0-9A-Z]+$"),
+    parent=StorageHost,
+    path=r"/[-_a-z0-9A-Z]+$",
     method="GET",
 )
 def list_blobs(request: MazureRequest) -> ResponseType:
@@ -74,8 +78,8 @@ def list_blobs(request: MazureRequest) -> ResponseType:
 
 
 @register(
-    host="https://[-_a-z0-9A-Z]+.blob.core.windows.net",
-    path=re.compile("/[-_a-z0-9A-Z]+/[-_a-z0-9A-Z]+"),
+    parent=StorageHost,
+    path=r"/[-_a-z0-9A-Z]+/[-_a-z0-9A-Z]+",
     method="PUT",
 )
 def upload_blob(request: MazureRequest) -> ResponseType:
@@ -93,8 +97,8 @@ def upload_blob(request: MazureRequest) -> ResponseType:
 
 
 @register(
-    host="https://[-_a-z0-9A-Z]+.blob.core.windows.net",
-    path=re.compile("^/[-_a-z0-9A-Z]+/[-_a-z0-9A-Z.]+$"),
+    parent=StorageHost,
+    path=r"/[-_a-z0-9A-Z]+/[-_a-z0-9A-Z.]+$",
     method="GET",
 )
 def download_blob(request: MazureRequest) -> ResponseType:

--- a/mazure/mazure_core/route_mapping.py
+++ b/mazure/mazure_core/route_mapping.py
@@ -1,15 +1,32 @@
+import re
 from typing import Callable, Dict, Pattern
 
 from mazure.mazure_core import ResponseType
 from mazure.mazure_core.mazure_request import MazureRequest
 
+registered_parents: Dict[type[object], str] = {}
+
 registered_services: Dict[
-    str, Dict[str, Dict[Pattern[str], Callable[[MazureRequest], ResponseType]]]
+    str, Dict[Pattern[str], Callable[[MazureRequest], ResponseType]]
 ] = {}
 
 
+def register_parent(path: str) -> Callable[[type[object]], type[object]]:
+    def _decorator(
+        func: type[object],
+    ) -> type[object]:
+        if len(func.__mro__) > 2:
+            registered_parents[func] = registered_parents[func.__mro__[1]] + path
+        else:
+            registered_parents[func] = path
+
+        return func
+
+    return _decorator
+
+
 def register(
-    host: str, path: Pattern[str], method: str
+    parent: type[object], path: str, method: str
 ) -> Callable[
     [Callable[[MazureRequest], ResponseType]], Callable[[MazureRequest], ResponseType]
 ]:
@@ -18,9 +35,9 @@ def register(
     ) -> "Callable[[MazureRequest], ResponseType]":
         if method not in registered_services:
             registered_services[method] = {}
-        if host not in registered_services[method]:
-            registered_services[method][host] = {}
-        registered_services[method][host][path] = func
+        parent_path = registered_parents[parent]
+
+        registered_services[method][re.compile(parent_path + path)] = func
 
         return func
 

--- a/mazure/mazure_core/service_discovery.py
+++ b/mazure/mazure_core/service_discovery.py
@@ -1,6 +1,5 @@
 import re
 from gzip import compress
-from typing import Any, Dict
 
 from mazure.mazure_core import ResponseType
 from mazure.mazure_core.mazure_request import MazureRequest
@@ -38,20 +37,10 @@ def execute(request: MazureRequest) -> ResponseType:
 
 
 def _get_response(request: MazureRequest) -> ResponseType:
-    status_code: int
-    res_headers: Dict[str, Any]
-    res_body: bytes
     if request.method in registered_services:
-        for host, operations in registered_services[request.method].items():
-            if re.match(host, request.host):
-                status_code, res_headers, res_body = 404, {}, ERROR_NOT_YET_IMPLEMENTED
+        for path, func in registered_services[request.method].items():
+            requested_path = request.host + request.path
+            if re.match(path, requested_path):
+                return func(request)
 
-                for path, func in operations.items():
-                    if re.match(path, request.path):
-                        return func(request)
-
-            else:
-                status_code, res_headers, res_body = 404, {}, ERROR_NOT_YET_IMPLEMENTED
-    else:
-        status_code, res_headers, res_body = 404, {}, ERROR_NOT_YET_IMPLEMENTED
-    return status_code, res_headers, res_body
+    return 404, {}, ERROR_NOT_YET_IMPLEMENTED

--- a/tests/tests_python/test_core/test_routing.py
+++ b/tests/tests_python/test_core/test_routing.py
@@ -1,0 +1,66 @@
+import re
+
+from mazure.mazure_core import ResponseType
+from mazure.mazure_core.mazure_request import MazureRequest
+from mazure.mazure_core.route_mapping import (
+    register,
+    register_parent,
+    registered_parents,
+    registered_services,
+)
+
+
+@register_parent(path="https://website.com")
+class WebsiteRoot:
+    pass
+
+
+@register_parent(path="/static")
+class WebsiteData(WebsiteRoot):
+    pass
+
+
+@register_parent(path="/js")
+class WebsiteJS(WebsiteData):
+    pass
+
+
+@register(WebsiteRoot, "/path", "GET")
+def get_path(request: MazureRequest) -> ResponseType:
+    return 404, {}, f"{request.host} never called".encode("utf-8")
+
+
+@register(WebsiteData, "/index.css", "GET")
+def get_css(request: MazureRequest) -> ResponseType:
+    return 404, {}, f"{request.host} never called".encode("utf-8")
+
+
+@register(WebsiteJS, "/f1.js", "GET")
+def get_js1(request: MazureRequest) -> ResponseType:
+    return 404, {}, f"{request.host} never called".encode("utf-8")
+
+
+@register(WebsiteJS, "/f2.js", "GET")
+def get_js2(request: MazureRequest) -> ResponseType:
+    return 404, {}, f"{request.host} never called".encode("utf-8")
+
+
+def test_roots_are_registered_correctly() -> None:
+    assert registered_parents[WebsiteRoot] == "https://website.com"
+    assert registered_parents[WebsiteData] == "https://website.com/static"
+    assert registered_parents[WebsiteJS] == "https://website.com/static/js"
+
+
+def test_paths_are_registered_correctly() -> None:
+    assert "GET" in registered_services
+
+    get_paths = registered_services["GET"]
+    assert (  # pylint: disable=comparison-with-callable
+        get_paths[re.compile("https://website.com/static/index.css")] == get_css
+    )
+    assert (  # pylint: disable=comparison-with-callable
+        get_paths[re.compile("https://website.com/static/js/f1.js")] == get_js1
+    )
+    assert (  # pylint: disable=comparison-with-callable
+        get_paths[re.compile("https://website.com/static/js/f2.js")] == get_js2
+    )


### PR DESCRIPTION
Adds a hierarchical system to register the hosts/paths that we want to intercept.

`https://graph.microsoft.com/rootlevel/childpath` would become:

 - https://graph.microsoft.com
   - /rootlevel
     - /childpath

This simplifies the creation of multiple paths under the same root.

(Part 1, as the paths will be simplified further in a part 2)